### PR TITLE
FEAT: 댓글을 DB에 저장

### DIFF
--- a/lib/resource/l10n/arb/intl_ko.arb
+++ b/lib/resource/l10n/arb/intl_ko.arb
@@ -35,5 +35,6 @@
     "failureCommentSubmit": "댓글 작성을 실패했습니다.",
     "@failureCommentSubmit": {},
     "retry": "다시 시도해주세요.",
-    "@retry": {}
+    "@retry": {},
+    "ok": "확인"
 }

--- a/lib/resource/l10n/arb/intl_ko.arb
+++ b/lib/resource/l10n/arb/intl_ko.arb
@@ -29,5 +29,9 @@
                 "type": "int"
             }
         }
-    }
+    },
+    "failureCommentSubmit": "댓글 작성을 실패했습니다.",
+    "@failureCommentSubmit": {},
+    "retry": "다시 시도해주세요.",
+    "@retry": {}
 }

--- a/lib/resource/l10n/arb/intl_ko.arb
+++ b/lib/resource/l10n/arb/intl_ko.arb
@@ -30,6 +30,8 @@
             }
         }
     },
+    "error": "오류",
+    "@error": {},
     "failureCommentSubmit": "댓글 작성을 실패했습니다.",
     "@failureCommentSubmit": {},
     "retry": "다시 시도해주세요.",

--- a/lib/src/core/constants/supabase.dart
+++ b/lib/src/core/constants/supabase.dart
@@ -53,4 +53,5 @@ final class CommentsTable {
   static const String content = 'content';
   static const String userUUID = 'user_uuid';
   static const String createAt = 'create_at';
+  static const String postID = 'post_id';
 }

--- a/lib/src/core/constants/supabase.dart
+++ b/lib/src/core/constants/supabase.dart
@@ -43,3 +43,14 @@ final class TagsCountRPC {
   static const String name = 'name';
   static const String postCount = 'post_count';
 }
+
+final class CommentsTable {
+  const CommentsTable._();
+
+  static const String tableName = 'comments';
+
+  static const String id = 'id';
+  static const String content = 'content';
+  static const String userUUID = 'user_uuid';
+  static const String createAt = 'create_at';
+}

--- a/lib/src/core/constants/supabase.dart
+++ b/lib/src/core/constants/supabase.dart
@@ -52,6 +52,6 @@ final class CommentsTable {
   static const String id = 'id';
   static const String content = 'content';
   static const String userUUID = 'user_uuid';
-  static const String createAt = 'create_at';
+  static const String createAt = 'created_at';
   static const String postID = 'post_id';
 }

--- a/lib/src/core/routes/app_routes.dart
+++ b/lib/src/core/routes/app_routes.dart
@@ -13,7 +13,7 @@ final class AppRoutes {
   );
 
   static final GoRoute post = GoRoute(
-    path: '/:id',
+    path: '/:route_id',
     builder: (context, state) {
       Post? post;
 

--- a/lib/src/core/utils/response_result.dart
+++ b/lib/src/core/utils/response_result.dart
@@ -1,11 +1,17 @@
 class ResponseResult<T> {
   final bool isSuccess;
   final T? data;
-  final String? message;
+  final Exception? exception;
 
   const ResponseResult({
     required this.isSuccess,
     this.data,
-    this.message,
+    this.exception,
   });
+
+  factory ResponseResult.isSuccess(T data) =>
+      ResponseResult(isSuccess: true, data: data);
+
+  factory ResponseResult.isFailure(Exception exception) =>
+      ResponseResult(isSuccess: false, exception: exception);
 }

--- a/lib/src/core/utils/response_result.dart
+++ b/lib/src/core/utils/response_result.dart
@@ -1,0 +1,11 @@
+class ResponseResult<T> {
+  final bool isSuccess;
+  final T? data;
+  final String? message;
+
+  const ResponseResult({
+    required this.isSuccess,
+    this.data,
+    this.message,
+  });
+}

--- a/lib/src/data/data_sources/supabase_auth_service.dart
+++ b/lib/src/data/data_sources/supabase_auth_service.dart
@@ -3,6 +3,8 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class SupabaseAuthService {
   final GoTrueClient _auth = Supabase.instance.client.auth;
 
+  User? get currentUser => _auth.currentUser;
+
   Future<bool> loginWithGithub(String redirectURL) async {
     return _auth.signInWithOAuth(
       OAuthProvider.github,

--- a/lib/src/data/data_sources/supabase_auth_service.dart
+++ b/lib/src/data/data_sources/supabase_auth_service.dart
@@ -17,4 +17,8 @@ class SupabaseAuthService {
   bool isLogin() {
     return _auth.currentUser != null;
   }
+
+  Future<User?> getUser(String uid) {
+    return _auth.admin.getUserById(uid).then((value) => value.user);
+  }
 }

--- a/lib/src/data/data_sources/supabase_database_service.dart
+++ b/lib/src/data/data_sources/supabase_database_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kkw_blog/src/core/constants/supabase.dart';
+import 'package:kkw_blog/src/core/utils/response_result.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
 import 'package:kkw_blog/src/data/entities/comment.dart';
 import 'package:kkw_blog/src/data/entities/post.dart';
@@ -48,10 +49,10 @@ class SupabaseDatabaseService {
         }).then((result) => Post.fromJson(result.single));
   }
 
-  Future<void> saveComment(Map<String, dynamic> data) {
-    return _client
-        .from(CommentsTable.tableName)
-        .insert(data)
-        .catchError((error) {});
+  Future<ResponseResult> saveComment(Map<String, dynamic> data) {
+    return _client.from(CommentsTable.tableName).insert({'test': 1}).then(
+      (value) => ResponseResult.isSuccess(null),
+      onError: (error, stackTrace) => ResponseResult.isFailure(error),
+    );
   }
 }

--- a/lib/src/data/data_sources/supabase_database_service.dart
+++ b/lib/src/data/data_sources/supabase_database_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:kkw_blog/src/core/constants/supabase.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
 import 'package:kkw_blog/src/data/entities/comment.dart';
@@ -48,6 +49,9 @@ class SupabaseDatabaseService {
   }
 
   Future<void> saveComment(Map<String, dynamic> data) {
-    return _client.from(CommentsTable.tableName).insert(data);
+    return _client
+        .from(CommentsTable.tableName)
+        .insert(data)
+        .catchError((error) {});
   }
 }

--- a/lib/src/data/data_sources/supabase_database_service.dart
+++ b/lib/src/data/data_sources/supabase_database_service.dart
@@ -50,9 +50,9 @@ class SupabaseDatabaseService {
   }
 
   Future<ResponseResult> saveComment(Map<String, dynamic> data) {
-    return _client.from(CommentsTable.tableName).insert({'test': 1}).then(
-      (value) => ResponseResult.isSuccess(null),
-      onError: (error, stackTrace) => ResponseResult.isFailure(error),
-    );
+    return _client.from(CommentsTable.tableName).insert(data).then(
+          (value) => ResponseResult.isSuccess(null),
+          onError: (error, stackTrace) => ResponseResult.isFailure(error),
+        );
   }
 }

--- a/lib/src/data/data_sources/supabase_database_service.dart
+++ b/lib/src/data/data_sources/supabase_database_service.dart
@@ -1,5 +1,6 @@
 import 'package:kkw_blog/src/core/constants/supabase.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
+import 'package:kkw_blog/src/data/entities/comment.dart';
 import 'package:kkw_blog/src/data/entities/post.dart';
 import 'package:kkw_blog/src/data/entities/tag_count.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -44,5 +45,9 @@ class SupabaseDatabaseService {
         params: {
           'post_name': name,
         }).then((result) => Post.fromJson(result.single));
+  }
+
+  Future<void> saveComment(Map<String, dynamic> data) {
+    return _client.from(CommentsTable.tableName).insert(data);
   }
 }

--- a/lib/src/data/entities/comment.dart
+++ b/lib/src/data/entities/comment.dart
@@ -11,6 +11,7 @@ class Comment with _$Comment {
     required String content,
     required String userUUID,
     @JsonKey(name: CommentsTable.createAt) required DateTime createAt,
+    @JsonKey(name: CommentsTable.postID) required int postID,
   }) = _Comment;
 
   factory Comment.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/data/entities/comment.dart
+++ b/lib/src/data/entities/comment.dart
@@ -7,10 +7,14 @@ part 'comment.g.dart';
 @freezed
 class Comment with _$Comment {
   const factory Comment({
-    required int? id,
+    @JsonKey(includeToJson: false) required int? id,
     required String content,
-    required String userUUID,
-    @JsonKey(name: CommentsTable.createAt) required DateTime createAt,
+    @JsonKey(name: CommentsTable.userUUID) required String userUUID,
+    @JsonKey(
+      name: CommentsTable.createAt,
+      includeToJson: false,
+    )
+    required DateTime? createAt,
     @JsonKey(name: CommentsTable.postID) required int postID,
   }) = _Comment;
 

--- a/lib/src/data/entities/comment.dart
+++ b/lib/src/data/entities/comment.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kkw_blog/src/core/constants/supabase.dart';
+
+part 'comment.freezed.dart';
+part 'comment.g.dart';
+
+@freezed
+class Comment with _$Comment {
+  const factory Comment({
+    required int? id,
+    required String content,
+    required String userUUID,
+    @JsonKey(name: CommentsTable.createAt) required DateTime createAt,
+  }) = _Comment;
+
+  factory Comment.fromJson(Map<String, dynamic> json) =>
+      _$CommentFromJson(json);
+}

--- a/lib/src/data/mappers/comment_mapper.dart
+++ b/lib/src/data/mappers/comment_mapper.dart
@@ -1,0 +1,14 @@
+import 'package:kkw_blog/src/domain/models/comment.dart' as Model;
+import 'package:kkw_blog/src/data/entities/comment.dart' as Entity;
+
+extension CommentModelMapper on Model.Comment {
+  Entity.Comment toEntity() {
+    return Entity.Comment(
+      id: id,
+      content: content,
+      userUUID: userUUID,
+      createAt: createAt,
+      postID: postID,
+    );
+  }
+}

--- a/lib/src/data/mappers/post_mapper.dart
+++ b/lib/src/data/mappers/post_mapper.dart
@@ -15,7 +15,8 @@ class PostMapper {
     String content = markdown.getContent();
 
     return Model.Post(
-      id: post.name,
+      id: post.id,
+      routeID: post.name,
       title: frontMatter['title'],
       content: content,
       category: post.categoryName,

--- a/lib/src/data/mappers/user_mapper.dart
+++ b/lib/src/data/mappers/user_mapper.dart
@@ -1,0 +1,12 @@
+import 'package:supabase_flutter/supabase_flutter.dart' as Entity;
+import 'package:kkw_blog/src/domain/models/user.dart' as Model;
+
+extension UserEntityMapper on Entity.User {
+  Model.User toModel() {
+    return Model.User(
+      uuid: id,
+      userName: userMetadata?['preferred_username'] ?? '',
+      avatar: userMetadata?['avatar_url'] ?? '',
+    );
+  }
+}

--- a/lib/src/data/repositories/supabase_auth_repository_impl.dart
+++ b/lib/src/data/repositories/supabase_auth_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:kkw_blog/src/data/data_sources/supabase_auth_service.dart';
+import 'package:kkw_blog/src/data/mappers/user_mapper.dart';
 import 'package:kkw_blog/src/domain/models/user.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_auth_repository.dart';
 
@@ -26,17 +27,9 @@ class SupabaseAuthRepositoryImpl implements SupabaseAuthRepository {
 
   @override
   Future<User?> getUser(String uid) {
-    return _authService.getUser(uid).then(
-      (value) {
-        if (value != null) {
-          return User(
-            uuid: value.id,
-            userName: value.userMetadata?['preferred_username'] ?? '',
-            avatar: value.userMetadata?['avatar_url'] ?? '',
-          );
-        }
-        return null;
-      },
-    );
+    return _authService.getUser(uid).then((value) => value?.toModel());
   }
+
+  @override
+  User? get currentUser => _authService.currentUser?.toModel();
 }

--- a/lib/src/data/repositories/supabase_auth_repository_impl.dart
+++ b/lib/src/data/repositories/supabase_auth_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:kkw_blog/src/data/data_sources/supabase_auth_service.dart';
+import 'package:kkw_blog/src/domain/models/user.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_auth_repository.dart';
 
 class SupabaseAuthRepositoryImpl implements SupabaseAuthRepository {
@@ -21,5 +22,21 @@ class SupabaseAuthRepositoryImpl implements SupabaseAuthRepository {
   @override
   bool isLogin() {
     return _authService.isLogin();
+  }
+
+  @override
+  Future<User?> getUser(String uid) {
+    return _authService.getUser(uid).then(
+      (value) {
+        if (value != null) {
+          return User(
+            uuid: value.id,
+            userName: value.userMetadata?['preferred_username'] ?? '',
+            avatar: value.userMetadata?['avatar_url'] ?? '',
+          );
+        }
+        return null;
+      },
+    );
   }
 }

--- a/lib/src/data/repositories/supabase_database_repository_impl.dart
+++ b/lib/src/data/repositories/supabase_database_repository_impl.dart
@@ -1,7 +1,9 @@
 import 'package:kkw_blog/src/data/data_sources/supabase_database_service.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
 import 'package:kkw_blog/src/data/entities/tag_count.dart';
+import 'package:kkw_blog/src/data/mappers/comment_mapper.dart';
 import 'package:kkw_blog/src/domain/models/classification_type.dart';
+import 'package:kkw_blog/src/domain/models/comment.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_database_repository.dart';
 
 class SupabaseDatabaseRepositoryImpl implements SupabaseDatabaseRepository {
@@ -40,5 +42,10 @@ class SupabaseDatabaseRepositoryImpl implements SupabaseDatabaseRepository {
               count: e.counts,
             ))
         .toSet();
+  }
+
+  @override
+  Future<void> saveComment(Comment comment) {
+    return _databaseService.saveComment(comment.toEntity().toJson());
   }
 }

--- a/lib/src/data/repositories/supabase_database_repository_impl.dart
+++ b/lib/src/data/repositories/supabase_database_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'package:kkw_blog/src/core/utils/response_result.dart';
 import 'package:kkw_blog/src/data/data_sources/supabase_database_service.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
 import 'package:kkw_blog/src/data/entities/tag_count.dart';
@@ -45,7 +46,7 @@ class SupabaseDatabaseRepositoryImpl implements SupabaseDatabaseRepository {
   }
 
   @override
-  Future<void> saveComment(Comment comment) {
+  Future<ResponseResult> saveComment(Comment comment) {
     return _databaseService.saveComment(comment.toEntity().toJson());
   }
 }

--- a/lib/src/domain/models/comment.dart
+++ b/lib/src/domain/models/comment.dart
@@ -10,5 +10,6 @@ class Comment with _$Comment {
     required String userName,
     required String content,
     required DateTime createAt,
+    required int postID,
   }) = _Comment;
 }

--- a/lib/src/domain/models/comment.dart
+++ b/lib/src/domain/models/comment.dart
@@ -5,6 +5,7 @@ part 'comment.freezed.dart';
 @freezed
 class Comment with _$Comment {
   const factory Comment({
+    required int? id,
     required String userUUID,
     required String userName,
     required String content,

--- a/lib/src/domain/models/comment.dart
+++ b/lib/src/domain/models/comment.dart
@@ -5,7 +5,7 @@ part 'comment.freezed.dart';
 @freezed
 class Comment with _$Comment {
   const factory Comment({
-    required int? id,
+    int? id,
     required String userUUID,
     required String userName,
     required String content,

--- a/lib/src/domain/models/comment.dart
+++ b/lib/src/domain/models/comment.dart
@@ -9,7 +9,7 @@ class Comment with _$Comment {
     required String userUUID,
     required String userName,
     required String content,
-    required DateTime createAt,
+    DateTime? createAt,
     required int postID,
   }) = _Comment;
 }

--- a/lib/src/domain/models/comment.dart
+++ b/lib/src/domain/models/comment.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'comment.freezed.dart';
+
+@freezed
+class Comment with _$Comment {
+  const factory Comment({
+    required String userUUID,
+    required String userName,
+    required String content,
+    required DateTime createAt,
+  }) = _Comment;
+}

--- a/lib/src/domain/models/post.dart
+++ b/lib/src/domain/models/post.dart
@@ -9,7 +9,8 @@ class Post with _$Post {
   const Post._();
 
   const factory Post({
-    required String id,
+    required int id,
+    required String routeID,
     required String title,
     required String content,
     required String category,
@@ -19,5 +20,5 @@ class Post with _$Post {
 
   String get createAtToString => DateFormat('yyyy년 MM월 dd일').format(createAt);
 
-  String get thumbnail => '$postBucketURL$id/thumbnail.png';
+  String get thumbnail => '$postBucketURL$routeID/thumbnail.png';
 }

--- a/lib/src/domain/models/user.dart
+++ b/lib/src/domain/models/user.dart
@@ -7,6 +7,6 @@ class User with _$User {
   const factory User({
     required String uuid,
     required String userName,
-    required String avatar,
+    required String? avatar,
   }) = _User;
 }

--- a/lib/src/domain/models/user.dart
+++ b/lib/src/domain/models/user.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user.freezed.dart';
+
+@freezed
+class User with _$User {
+  const factory User({
+    required String uuid,
+    required String userName,
+    required String avatar,
+  }) = _User;
+}

--- a/lib/src/domain/repositories/supabase_auth_repository.dart
+++ b/lib/src/domain/repositories/supabase_auth_repository.dart
@@ -1,5 +1,8 @@
+import 'package:kkw_blog/src/domain/models/user.dart';
+
 abstract interface class SupabaseAuthRepository {
   Future<bool> loginWithGithub(String redirectURL);
   Future<void> logout();
   bool isLogin();
+  Future<User?> getUser(String uid);
 }

--- a/lib/src/domain/repositories/supabase_auth_repository.dart
+++ b/lib/src/domain/repositories/supabase_auth_repository.dart
@@ -1,6 +1,7 @@
 import 'package:kkw_blog/src/domain/models/user.dart';
 
 abstract interface class SupabaseAuthRepository {
+  User? get currentUser;
   Future<bool> loginWithGithub(String redirectURL);
   Future<void> logout();
   bool isLogin();

--- a/lib/src/domain/repositories/supabase_database_repository.dart
+++ b/lib/src/domain/repositories/supabase_database_repository.dart
@@ -1,3 +1,4 @@
+import 'package:kkw_blog/src/core/utils/response_result.dart';
 import 'package:kkw_blog/src/domain/models/classification_type.dart';
 import 'package:kkw_blog/src/domain/models/comment.dart';
 
@@ -5,5 +6,5 @@ abstract interface class SupabaseDatabaseRepository {
   Future<int> getPostsCount();
   Future<Set<CategoryType>> getCategoriesCount();
   Future<Set<TagType>> getTagsCount();
-  Future<void> saveComment(Comment comment);
+  Future<ResponseResult> saveComment(Comment comment);
 }

--- a/lib/src/domain/repositories/supabase_database_repository.dart
+++ b/lib/src/domain/repositories/supabase_database_repository.dart
@@ -1,7 +1,9 @@
 import 'package:kkw_blog/src/domain/models/classification_type.dart';
+import 'package:kkw_blog/src/domain/models/comment.dart';
 
 abstract interface class SupabaseDatabaseRepository {
   Future<int> getPostsCount();
   Future<Set<CategoryType>> getCategoriesCount();
   Future<Set<TagType>> getTagsCount();
+  Future<void> saveComment(Comment comment);
 }

--- a/lib/src/presentation/pages/main_page/local_widgets/preview.dart
+++ b/lib/src/presentation/pages/main_page/local_widgets/preview.dart
@@ -16,7 +16,7 @@ class Preview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => context.push('/${post.id}', extra: post),
+      onTap: () => context.push('/${post.routeID}', extra: post),
       child: LayoutBuilder(
         builder: (context, constraints) {
           return Column(

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -289,8 +289,10 @@ class _CompletedButton extends ConsumerWidget {
     await ref
         .read(postNotifierProvider.notifier)
         .submitComment(content)
-        .then((_) {
-      textEditingController.clear();
+        .then((value) {
+      if (value != null && value.isSuccess) {
+        textEditingController.clear();
+      }
     });
 
     context.pop();

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -8,8 +8,11 @@ import 'package:kkw_blog/resource/assets.dart';
 import 'package:kkw_blog/resource/l10n/generated/l10n.dart';
 import 'package:kkw_blog/resource/values/theme.dart';
 import 'package:kkw_blog/src/core/routes/app_routes.dart';
+import 'package:kkw_blog/src/core/utils/response_result.dart';
 import 'package:kkw_blog/src/presentation/riverpods/post_notifier.dart';
 import 'dart:html' as html;
+
+import 'package:kkw_blog/src/presentation/widgets/error_dialog.dart';
 
 class _ControllersProvider extends InheritedWidget {
   final TabController tabController;
@@ -286,16 +289,21 @@ class _CompletedButton extends ConsumerWidget {
       barrierDismissible: false,
     );
 
-    await ref
+    ResponseResult? responseResult = await ref
         .read(postNotifierProvider.notifier)
         .submitComment(content)
         .then((value) {
-      if (value != null && value.isSuccess) {
-        textEditingController.clear();
-      }
+      context.pop();
+
+      return value;
     });
 
-    context.pop();
+    if (responseResult != null && !responseResult.isSuccess) {
+      showErrorDialog(
+        context: context,
+        errorMsg: Messages.of(context).failureCommentSubmit,
+      );
+    }
   }
 }
 

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -313,11 +313,7 @@ class _LogoutPanel extends ConsumerWidget {
   void _logout(WidgetRef ref) {
     PostNotifier postNotifier = ref.read(postNotifierProvider.notifier);
 
-    postNotifier.logout().then(
-      (value) {
-        postNotifier.isLogin = false;
-      },
-    );
+    postNotifier.logout().then((value) => postNotifier.updateUser());
   }
 }
 

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -13,6 +13,7 @@ import 'package:kkw_blog/src/presentation/riverpods/post_notifier.dart';
 import 'dart:html' as html;
 
 import 'package:kkw_blog/src/presentation/widgets/error_dialog.dart';
+import 'package:kkw_blog/src/presentation/widgets/loading_dialog.dart';
 
 class _ControllersProvider extends InheritedWidget {
   final TabController tabController;
@@ -281,13 +282,7 @@ class _CompletedButton extends ConsumerWidget {
 
     if (content.isEmpty) return;
 
-    showDialog(
-      context: context,
-      builder: (_) => const Center(
-        child: CircularProgressIndicator(),
-      ),
-      barrierDismissible: false,
-    );
+    showLoadingDialog(context);
 
     ResponseResult? responseResult = await ref
         .read(postNotifierProvider.notifier)

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kkw_blog/resource/assets.dart';
 import 'package:kkw_blog/resource/l10n/generated/l10n.dart';
 import 'package:kkw_blog/resource/values/theme.dart';
+import 'package:kkw_blog/src/core/routes/app_routes.dart';
 import 'package:kkw_blog/src/presentation/riverpods/post_notifier.dart';
 import 'dart:html' as html;
 
@@ -247,7 +249,7 @@ class _CompletedButton extends ConsumerWidget {
         ref.watch(postNotifierProvider.select((value) => value.isLogin));
 
     return ElevatedButton(
-      onPressed: isLogin ? () {} : null,
+      onPressed: isLogin ? () => _submit(context, ref) : null,
       style: ButtonStyle(
         mouseCursor: WidgetStatePropertyAll(
             isLogin ? null : SystemMouseCursors.forbidden),
@@ -266,6 +268,32 @@ class _CompletedButton extends ConsumerWidget {
         style: TextStyle(color: colorScheme.primary),
       ),
     );
+  }
+
+  void _submit(BuildContext context, WidgetRef ref) async {
+    TextEditingController textEditingController =
+        _ControllersProvider.of(context).textEditingController;
+    String content =
+        _ControllersProvider.of(context).textEditingController.text;
+
+    if (content.isEmpty) return;
+
+    showDialog(
+      context: context,
+      builder: (_) => const Center(
+        child: CircularProgressIndicator(),
+      ),
+      barrierDismissible: false,
+    );
+
+    await ref
+        .read(postNotifierProvider.notifier)
+        .submitComment(content)
+        .then((_) {
+      textEditingController.clear();
+    });
+
+    context.pop();
   }
 }
 

--- a/lib/src/presentation/pages/post_page/local_widgets/markdown_view.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/markdown_view.dart
@@ -5,13 +5,13 @@ import 'package:kkw_blog/resource/values/theme.dart';
 import 'package:kkw_blog/src/core/constants/supabase.dart';
 
 class MarkdownView extends StatelessWidget {
-  final String id;
+  final String routeID;
   final String content;
 
   const MarkdownView({
     super.key,
     required this.content,
-    required this.id,
+    required this.routeID,
   });
 
   @override
@@ -24,9 +24,9 @@ class MarkdownView extends StatelessWidget {
         Widget child;
 
         if (RegExp(r'.svg').hasMatch(originUri)) {
-          child = SvgPicture.network('$postBucketURL$id/$originUri');
+          child = SvgPicture.network('$postBucketURL$routeID/$originUri');
         } else {
-          child = Image.network('$postBucketURL$id/$originUri');
+          child = Image.network('$postBucketURL$routeID/$originUri');
         }
 
         return Container(

--- a/lib/src/presentation/pages/post_page/post_page.dart
+++ b/lib/src/presentation/pages/post_page/post_page.dart
@@ -86,7 +86,7 @@ class PostPage extends BasedScrollLayout {
                   const SliverToBoxAdapter(child: Divider()),
                   SliverToBoxAdapter(
                     child: MarkdownView(
-                      id: post.id,
+                      routeID: post.routeID,
                       content: post.content,
                     ),
                   ),

--- a/lib/src/presentation/pages/post_page/post_page.dart
+++ b/lib/src/presentation/pages/post_page/post_page.dart
@@ -32,13 +32,13 @@ class PostPage extends BasedScrollLayout {
     final ScrollController commentScrollController = useScrollController();
 
     useEffect(() {
-      String? id = _getIDParameter();
+      String? routeID = _getIDParameter();
 
       Future.delayed(Duration.zero).then(
         (value) {
           ref.read(postNotifierProvider.notifier).updatePost(
                 post: this.post,
-                fileName: id,
+                fileName: routeID,
               );
         },
       );
@@ -118,6 +118,8 @@ class PostPage extends BasedScrollLayout {
   String? _getIDParameter() {
     Object? argument = ModalRoute.settingsOf(useContext())?.arguments;
 
-    return argument != null ? (argument as Map<String, dynamic>)['id'] : null;
+    return argument != null
+        ? (argument as Map<String, dynamic>)['route_id']
+        : null;
   }
 }

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:kkw_blog/src/dependency_injection.dart';
+import 'package:kkw_blog/src/domain/models/comment.dart';
 import 'package:kkw_blog/src/domain/models/post.dart';
 import 'package:kkw_blog/src/domain/models/user.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_auth_repository.dart';
@@ -46,6 +47,20 @@ class PostNotifier extends _$PostNotifier {
     User? user = _supabaseAuthRepository.currentUser;
 
     state = state.copyWith(user: user);
+  }
+
+  void submitComment(String content) {
+    if (state.post == null || !state.isLogin) return;
+
+    Comment comment = Comment(
+      userUUID: state.user!.uuid,
+      userName: state.user!.userName,
+      content: content,
+      createAt: DateTime.now(),
+      postID: state.post!.id,
+    );
+
+    _supabaseDatabaseRepository.saveComment(comment);
   }
 }
 

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -50,8 +50,8 @@ class PostNotifier extends _$PostNotifier {
     state = state.copyWith(user: user);
   }
 
-  Future<ResponseResult> submitComment(String content) async {
-    if (state.post == null || !state.isLogin) return;
+  Future<ResponseResult?> submitComment(String content) async {
+    if (state.post == null || !state.isLogin) return null;
 
     Comment comment = Comment(
       userUUID: state.user!.uuid,

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -3,6 +3,7 @@ import 'package:kkw_blog/src/dependency_injection.dart';
 import 'package:kkw_blog/src/domain/models/post.dart';
 import 'package:kkw_blog/src/domain/models/user.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_auth_repository.dart';
+import 'package:kkw_blog/src/domain/repositories/supabase_database_repository.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_stroage_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -13,10 +14,12 @@ part 'post_notifier.freezed.dart';
 class PostNotifier extends _$PostNotifier {
   late final SupabaseStorageRepository _supabaseStorageRepository;
   late final SupabaseAuthRepository _supabaseAuthRepository;
+  late final SupabaseDatabaseRepository _supabaseDatabaseRepository;
 
   PostNotifier()
       : _supabaseStorageRepository = instance<SupabaseStorageRepository>(),
-        _supabaseAuthRepository = instance<SupabaseAuthRepository>();
+        _supabaseAuthRepository = instance<SupabaseAuthRepository>(),
+        _supabaseDatabaseRepository = instance<SupabaseDatabaseRepository>();
 
   @override
   PostNotifierState build() => PostNotifierState(

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:kkw_blog/src/dependency_injection.dart';
 import 'package:kkw_blog/src/domain/models/post.dart';
+import 'package:kkw_blog/src/domain/models/user.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_auth_repository.dart';
 import 'package:kkw_blog/src/domain/repositories/supabase_stroage_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -19,11 +20,8 @@ class PostNotifier extends _$PostNotifier {
 
   @override
   PostNotifierState build() => PostNotifierState(
-        post: null,
-        isLogin: _supabaseAuthRepository.isLogin(),
+        user: _supabaseAuthRepository.currentUser,
       );
-
-  set isLogin(bool value) => state = state.copyWith(isLogin: value);
 
   void updatePost({Post? post, String? fileName}) async {
     if (fileName == null) return;
@@ -40,12 +38,22 @@ class PostNotifier extends _$PostNotifier {
   Future<void> logout() {
     return _supabaseAuthRepository.logout();
   }
+
+  void updateUser() async {
+    User? user = _supabaseAuthRepository.currentUser;
+
+    state = state.copyWith(user: user);
+  }
 }
 
 @freezed
 class PostNotifierState with _$PostNotifierState {
+  const PostNotifierState._();
+
   const factory PostNotifierState({
-    required Post? post,
-    required bool isLogin,
+    Post? post,
+    User? user,
   }) = _PostNotifierState;
+
+  bool get isLogin => user != null;
 }

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -49,18 +49,17 @@ class PostNotifier extends _$PostNotifier {
     state = state.copyWith(user: user);
   }
 
-  void submitComment(String content) {
+  Future<void> submitComment(String content) async {
     if (state.post == null || !state.isLogin) return;
 
     Comment comment = Comment(
       userUUID: state.user!.uuid,
       userName: state.user!.userName,
       content: content,
-      createAt: DateTime.now(),
       postID: state.post!.id,
     );
 
-    _supabaseDatabaseRepository.saveComment(comment);
+    await _supabaseDatabaseRepository.saveComment(comment);
   }
 }
 

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kkw_blog/src/core/utils/response_result.dart';
 import 'package:kkw_blog/src/dependency_injection.dart';
 import 'package:kkw_blog/src/domain/models/comment.dart';
 import 'package:kkw_blog/src/domain/models/post.dart';
@@ -49,7 +50,7 @@ class PostNotifier extends _$PostNotifier {
     state = state.copyWith(user: user);
   }
 
-  Future<void> submitComment(String content) async {
+  Future<ResponseResult> submitComment(String content) async {
     if (state.post == null || !state.isLogin) return;
 
     Comment comment = Comment(
@@ -59,7 +60,7 @@ class PostNotifier extends _$PostNotifier {
       postID: state.post!.id,
     );
 
-    await _supabaseDatabaseRepository.saveComment(comment);
+    return _supabaseDatabaseRepository.saveComment(comment);
   }
 }
 

--- a/lib/src/presentation/widgets/error_dialog.dart
+++ b/lib/src/presentation/widgets/error_dialog.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kkw_blog/resource/l10n/generated/l10n.dart';
+
+class ErrorDialog extends StatelessWidget {
+  final String errorMsg;
+
+  const ErrorDialog(this.errorMsg, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        Messages.of(context).error,
+        style: TextStyle(color: Theme.of(context).colorScheme.error),
+      ),
+      content: Text('$errorMsg\n\n${Messages.of(context).retry}'),
+      actions: [
+        TextButton(
+          onPressed: () => context.pop(),
+          child: Text(Messages.of(context).ok),
+        ),
+      ],
+    );
+  }
+}
+
+Future<T?> showErrorDialog<T>({
+  required BuildContext context,
+  required String errorMsg,
+}) =>
+    showDialog<T>(
+      context: context,
+      builder: (_) => ErrorDialog(errorMsg),
+    );

--- a/lib/src/presentation/widgets/loading_dialog.dart
+++ b/lib/src/presentation/widgets/loading_dialog.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class LoadingDialog extends StatelessWidget {
+  const LoadingDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: CircularProgressIndicator(),
+    );
+  }
+}
+
+void showLoadingDialog(BuildContext context) => showDialog(
+      context: context,
+      builder: (_) => const LoadingDialog(),
+      barrierDismissible: false,
+    );


### PR DESCRIPTION
### Feature
- CommentsTable 데이터 객체 생성
- ResponseResult 데이터 객체 생성
- 현재 로그인된 유저와 uid를 이용한 유저 가져오는 기능 추가
- Comment 데이터 객체 생성 (Model/Entity)
  - Model <=> Entity Mapper 추가
- Post id를 table id로 변경 및 기존 id를 route id로 교체
- CommentField 에서 사용하는 controller를 관리하는 controllersProvider 생성
- 작성완료 클릭 시 댓글 저장 및 오류가 발생하면 오류 처리

### Style
- 오류 다이얼로그 관련 문구 추가
- 댓글 작성 실패 문구 추가