### PR TITLE
FEAT: post 별 댓글을 가져옴

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 supabase_url="your supabase url"
-supabase_key="your supabase key"
+supabase_anno_key="your supabase anno key"
+supabase_role_key="your supabase role key"

--- a/.github/workflows/deploy_web.yaml
+++ b/.github/workflows/deploy_web.yaml
@@ -23,7 +23,7 @@ jobs:
       run : flutter pub run build_runner build && flutter pub run intl_utils:generate
 
     - name: Build Web 
-      run: flutter build web --release --dart-define=supabase_key=${{ secrets.SUPABASE_KEY }} --dart-define=supabase_url=${{ secrets.SUPABASE_URL }}
+      run: flutter build web --release --dart-define=supabase_url=${{ secrets.SUPABASE_URL }} --dart-define=supabase_anno_key=${{ secrets.SUPABASE_ANNO_KEY }} --dart-define=supabase_role_key=${{ secrets.SUPABASE_ROLE_KEY }} 
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3.9.3

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ void main() async {
 
   await Supabase.initialize(
     url: supabaseUrl,
-    anonKey: supabaseKey,
+    anonKey: supabaseAnnoKey,
   );
 
   await initializeDateFormatting();

--- a/lib/src/core/constants/supabase.dart
+++ b/lib/src/core/constants/supabase.dart
@@ -1,5 +1,6 @@
 const supabaseUrl = String.fromEnvironment('supabase_url');
-const supabaseKey = String.fromEnvironment('supabase_key');
+const supabaseAnnoKey = String.fromEnvironment('supabase_anno_key');
+const supabaseRoleKey = String.fromEnvironment('supabase_role_key');
 
 const String postBucketID = 'posts';
 
@@ -48,6 +49,7 @@ final class CommentsTable {
   const CommentsTable._();
 
   static const String tableName = 'comments';
+  static const String functionName = 'get_comments_in_post';
 
   static const String id = 'id';
   static const String content = 'content';

--- a/lib/src/data/data_sources/supabase_auth_service.dart
+++ b/lib/src/data/data_sources/supabase_auth_service.dart
@@ -1,3 +1,4 @@
+import 'package:kkw_blog/src/core/constants/supabase.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SupabaseAuthService {
@@ -21,6 +22,8 @@ class SupabaseAuthService {
   }
 
   Future<User?> getUser(String uid) {
-    return _auth.admin.getUserById(uid).then((value) => value.user);
+    SupabaseClient adminClient = SupabaseClient(supabaseUrl, supabaseRoleKey);
+
+    return adminClient.auth.admin.getUserById(uid).then((value) => value.user);
   }
 }

--- a/lib/src/data/data_sources/supabase_database_service.dart
+++ b/lib/src/data/data_sources/supabase_database_service.dart
@@ -1,6 +1,7 @@
 import 'package:kkw_blog/src/core/constants/supabase.dart';
 import 'package:kkw_blog/src/core/utils/response_result.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
+import 'package:kkw_blog/src/data/entities/comment.dart';
 import 'package:kkw_blog/src/data/entities/post.dart';
 import 'package:kkw_blog/src/data/entities/tag_count.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -52,5 +53,12 @@ class SupabaseDatabaseService {
           (value) => ResponseResult.isSuccess(null),
           onError: (error, stackTrace) => ResponseResult.isFailure(error),
         );
+  }
+
+  Future<List<Comment>> getComments(int postID) {
+    return _client.rpc<List<Map<String, dynamic>>>(
+      CommentsTable.functionName,
+      params: {'p_post_id': postID},
+    ).then((result) => result.map((data) => Comment.fromJson(data)).toList());
   }
 }

--- a/lib/src/data/mappers/comment_mapper.dart
+++ b/lib/src/data/mappers/comment_mapper.dart
@@ -20,7 +20,7 @@ extension CommentEntityMapper on Entity.Comment {
       id: id,
       content: content,
       user: user,
-      createAt: createAt,
+      createAt: createAt?.toLocal(),
       postID: postID,
     );
   }

--- a/lib/src/data/mappers/comment_mapper.dart
+++ b/lib/src/data/mappers/comment_mapper.dart
@@ -1,12 +1,25 @@
 import 'package:kkw_blog/src/domain/models/comment.dart' as Model;
 import 'package:kkw_blog/src/data/entities/comment.dart' as Entity;
+import 'package:kkw_blog/src/domain/models/user.dart';
 
 extension CommentModelMapper on Model.Comment {
   Entity.Comment toEntity() {
     return Entity.Comment(
       id: id,
       content: content,
-      userUUID: userUUID,
+      userUUID: user.uuid,
+      createAt: createAt,
+      postID: postID,
+    );
+  }
+}
+
+extension CommentEntityMapper on Entity.Comment {
+  Model.Comment toModel({required User user}) {
+    return Model.Comment(
+      id: id,
+      content: content,
+      user: user,
       createAt: createAt,
       postID: postID,
     );

--- a/lib/src/data/repositories/supabase_database_repository_impl.dart
+++ b/lib/src/data/repositories/supabase_database_repository_impl.dart
@@ -70,7 +70,7 @@ class SupabaseDatabaseRepositoryImpl implements SupabaseDatabaseRepository {
 
       commentsModel.add(
         commentEntity.toModel(
-          user: user != null ? user!.toModel() : Model.User.unknown(),
+          user: user != null ? user.toModel() : Model.User.unknown(),
         ),
       );
     }

--- a/lib/src/data/repositories/supabase_database_repository_impl.dart
+++ b/lib/src/data/repositories/supabase_database_repository_impl.dart
@@ -1,18 +1,26 @@
 import 'package:kkw_blog/src/core/utils/response_result.dart';
+import 'package:kkw_blog/src/data/data_sources/supabase_auth_service.dart';
 import 'package:kkw_blog/src/data/data_sources/supabase_database_service.dart';
 import 'package:kkw_blog/src/data/entities/category_count.dart';
 import 'package:kkw_blog/src/data/entities/tag_count.dart';
+import 'package:kkw_blog/src/data/entities/comment.dart' as Entity;
 import 'package:kkw_blog/src/data/mappers/comment_mapper.dart';
+import 'package:kkw_blog/src/data/mappers/user_mapper.dart';
 import 'package:kkw_blog/src/domain/models/classification_type.dart';
-import 'package:kkw_blog/src/domain/models/comment.dart';
+import 'package:kkw_blog/src/domain/models/comment.dart' as Model;
+import 'package:kkw_blog/src/domain/models/user.dart' as Model;
 import 'package:kkw_blog/src/domain/repositories/supabase_database_repository.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SupabaseDatabaseRepositoryImpl implements SupabaseDatabaseRepository {
   late final SupabaseDatabaseService _databaseService;
+  late final SupabaseAuthService _authService;
 
   SupabaseDatabaseRepositoryImpl({
     required SupabaseDatabaseService databaseSerivce,
-  }) : _databaseService = databaseSerivce;
+    required SupabaseAuthService authService,
+  })  : _databaseService = databaseSerivce,
+        _authService = authService;
 
   @override
   Future<int> getPostsCount() {
@@ -46,7 +54,27 @@ class SupabaseDatabaseRepositoryImpl implements SupabaseDatabaseRepository {
   }
 
   @override
-  Future<ResponseResult> saveComment(Comment comment) {
+  Future<ResponseResult> saveComment(Model.Comment comment) {
     return _databaseService.saveComment(comment.toEntity().toJson());
+  }
+
+  @override
+  Future<List<Model.Comment>> getComments(int postID) async {
+    List<Entity.Comment> commentsEntity =
+        await _databaseService.getComments(postID);
+
+    List<Model.Comment> commentsModel = [];
+
+    for (Entity.Comment commentEntity in commentsEntity) {
+      User? user = await _authService.getUser(commentEntity.userUUID);
+
+      commentsModel.add(
+        commentEntity.toModel(
+          user: user != null ? user!.toModel() : Model.User.unknown(),
+        ),
+      );
+    }
+
+    return commentsModel;
   }
 }

--- a/lib/src/dependency_injection.dart
+++ b/lib/src/dependency_injection.dart
@@ -29,6 +29,7 @@ void initializeDI() {
   SupabaseDatabaseRepository supabaseDatabaseRepository =
       SupabaseDatabaseRepositoryImpl(
     databaseSerivce: supabaseDatabaseService,
+    authService: supabaseAuthService,
   );
 
   SupabaseAuthRepository supabaseAuthRepository = SupabaseAuthRepositoryImpl(

--- a/lib/src/domain/models/comment.dart
+++ b/lib/src/domain/models/comment.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kkw_blog/src/domain/models/user.dart';
 
 part 'comment.freezed.dart';
 
@@ -6,8 +7,7 @@ part 'comment.freezed.dart';
 class Comment with _$Comment {
   const factory Comment({
     int? id,
-    required String userUUID,
-    required String userName,
+    required User user,
     required String content,
     DateTime? createAt,
     required int postID,

--- a/lib/src/domain/models/user.dart
+++ b/lib/src/domain/models/user.dart
@@ -9,4 +9,10 @@ class User with _$User {
     required String userName,
     required String? avatar,
   }) = _User;
+
+  factory User.unknown() => const User(
+        uuid: '',
+        userName: 'UnknownUser',
+        avatar: '',
+      );
 }

--- a/lib/src/domain/repositories/supabase_database_repository.dart
+++ b/lib/src/domain/repositories/supabase_database_repository.dart
@@ -7,4 +7,5 @@ abstract interface class SupabaseDatabaseRepository {
   Future<Set<CategoryType>> getCategoriesCount();
   Future<Set<TagType>> getTagsCount();
   Future<ResponseResult> saveComment(Comment comment);
+  Future<List<Comment>> getComments(int postID);
 }

--- a/lib/src/presentation/pages/main_page/local_widgets/preview.dart
+++ b/lib/src/presentation/pages/main_page/local_widgets/preview.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kkw_blog/src/domain/models/post.dart';
-import 'package:kkw_blog/src/presentation/widgets/loading_dialog.dart';
 import 'package:kkw_blog/src/presentation/widgets/tags.dart';
 import 'package:kkw_blog/src/presentation/widgets/upload_date_and_category.dart';
 import 'package:markdown/markdown.dart' as Markdown;

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -293,6 +293,8 @@ class _CompletedButton extends ConsumerWidget {
 
     if (responseResult != null && responseResult.isSuccess) {
       textEditingController.clear();
+
+      ref.read(postNotifierProvider.notifier).updateComment();
     } else {
       showErrorDialog(
         context: context,

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_field.dart
@@ -291,7 +291,9 @@ class _CompletedButton extends ConsumerWidget {
       return value;
     });
 
-    if (responseResult != null && !responseResult.isSuccess) {
+    if (responseResult != null && responseResult.isSuccess) {
+      textEditingController.clear();
+    } else {
       showErrorDialog(
         context: context,
         errorMsg: Messages.of(context).failureCommentSubmit,

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_info.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_info.dart
@@ -1,19 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kkw_blog/resource/l10n/generated/l10n.dart';
+import 'package:kkw_blog/src/presentation/riverpods/post_notifier.dart';
 
 class CommentInfo extends StatelessWidget {
   const CommentInfo({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return const Row(
       children: [
-        Text(Messages.of(context).commentCount(0)),
-        const SizedBox(width: 8),
-        const Expanded(
+        SizedBox(width: 8),
+        _CommentCount(),
+        Expanded(
           child: Divider(),
         ),
       ],
     );
+  }
+}
+
+class _CommentCount extends ConsumerWidget {
+  const _CommentCount({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    int count = ref
+        .watch(postNotifierProvider.select((value) => value.comments.length));
+
+    return Text(Messages.of(context).commentCount(count));
   }
 }

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_info.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_info.dart
@@ -21,7 +21,7 @@ class CommentInfo extends StatelessWidget {
 }
 
 class _CommentCount extends ConsumerWidget {
-  const _CommentCount({super.key});
+  const _CommentCount();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_view.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_view.dart
@@ -27,7 +27,7 @@ class CommentView extends StatelessWidget {
                 maxLines: 1,
               ),
             ),
-            Text(DateFormat('yyyy/MM/dd hh:mm').format(comment.createAt!)),
+            Text(DateFormat('yyyy/MM/dd hh:mm a').format(comment.createAt!)),
           ],
         ),
         const SizedBox(height: 8),

--- a/lib/src/presentation/pages/post_page/local_widgets/comment_view.dart
+++ b/lib/src/presentation/pages/post_page/local_widgets/comment_view.dart
@@ -1,23 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:kkw_blog/src/domain/models/comment.dart';
 
 class CommentView extends StatelessWidget {
-  const CommentView({super.key});
+  final Comment comment;
+
+  const CommentView({
+    super.key,
+    required this.comment,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Row(
+        Row(
           children: [
-            CircleAvatar(),
-            SizedBox(width: 8),
-            Text('유저 이름'),
-            Spacer(),
-            Text('yyyy/MM/dd'),
+            CircleAvatar(
+              foregroundImage: NetworkImage(comment.user.avatar ?? ''),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                comment.user.userName,
+                maxLines: 1,
+              ),
+            ),
+            Text(DateFormat('yyyy/MM/dd hh:mm').format(comment.createAt!)),
           ],
         ),
         const SizedBox(height: 8),
-        Text('쀏' * 500),
+        Text(comment.content),
       ],
     );
   }

--- a/lib/src/presentation/pages/post_page/post_page.dart
+++ b/lib/src/presentation/pages/post_page/post_page.dart
@@ -36,7 +36,7 @@ class PostPage extends BasedScrollLayout {
 
       Future.delayed(Duration.zero).then(
         (value) {
-          ref.read(postNotifierProvider.notifier).updatePost(
+          ref.read(postNotifierProvider.notifier).updatePostAndComments(
                 post: this.post,
                 fileName: routeID,
               );

--- a/lib/src/presentation/pages/post_page/sliver_widgets/comment_listview.dart
+++ b/lib/src/presentation/pages/post_page/sliver_widgets/comment_listview.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kkw_blog/src/domain/models/comment.dart';
 import 'package:kkw_blog/src/presentation/pages/post_page/local_widgets/comment_view.dart';
+import 'package:kkw_blog/src/presentation/riverpods/post_notifier.dart';
 
-class CommentListview extends StatelessWidget {
+class CommentListview extends ConsumerWidget {
   const CommentListview({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    List<Comment> comments =
+        ref.watch(postNotifierProvider.select((value) => value.comments));
+
     return SliverList.builder(
-      itemBuilder: (context, index) => const Padding(
-        padding: EdgeInsets.symmetric(vertical: 8),
-        child: CommentView(),
+      itemBuilder: (context, index) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: CommentView(
+          comment: comments[index],
+        ),
       ),
-      itemCount: 10,
+      itemCount: comments.length,
     );
   }
 }

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -66,6 +66,13 @@ class PostNotifier extends _$PostNotifier {
 
     return _supabaseDatabaseRepository.saveComment(comment);
   }
+
+  void updateComment() async {
+    List<Comment> comments =
+        await _supabaseDatabaseRepository.getComments(state.post!.id);
+
+    state = state.copyWith(comments: comments);
+  }
 }
 
 @freezed

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -28,12 +28,17 @@ class PostNotifier extends _$PostNotifier {
         user: _supabaseAuthRepository.currentUser,
       );
 
-  void updatePost({Post? post, String? fileName}) async {
+  void updatePostAndComments({Post? post, String? fileName}) async {
     if (fileName == null) return;
 
     post ??= await _supabaseStorageRepository.getPostFile(fileName);
+    List<Comment> comments =
+        await _supabaseDatabaseRepository.getComments(post.id);
 
-    state = state.copyWith(post: post);
+    state = state.copyWith(
+      post: post,
+      comments: comments,
+    );
   }
 
   Future<bool> loginWithGithub(String redirectURL) {
@@ -70,6 +75,7 @@ class PostNotifierState with _$PostNotifierState {
   const factory PostNotifierState({
     Post? post,
     User? user,
+    @Default([]) List<Comment> comments,
   }) = _PostNotifierState;
 
   bool get isLogin => user != null;

--- a/lib/src/presentation/riverpods/post_notifier.dart
+++ b/lib/src/presentation/riverpods/post_notifier.dart
@@ -54,8 +54,7 @@ class PostNotifier extends _$PostNotifier {
     if (state.post == null || !state.isLogin) return null;
 
     Comment comment = Comment(
-      userUUID: state.user!.uuid,
-      userName: state.user!.userName,
+      user: state.user!,
       content: content,
       postID: state.post!.id,
     );


### PR DESCRIPTION
### Feature
- get_comments_in_post function을 통해 post 별 comment table 가져옴
- CommentEntityMapper 생성
- Entity.Comment의 userUUID와 userName을 Entity.User로 변경
- Service로 부터 받아온 댓글을 UI에 표시

### Build
- Service anno key와 Service role key 분리